### PR TITLE
Updating the lead count for each category

### DIFF
--- a/leads/models.py
+++ b/leads/models.py
@@ -64,6 +64,7 @@ class Agent(models.Model):
 
 class Category(models.Model):
     name = models.CharField(max_length=30)  # New, Contacted, Converted, Unconverted
+    number = models.IntegerField(default=0)
     organisation = models.ForeignKey(UserProfile, on_delete=models.CASCADE)
 
     def __str__(self):

--- a/leads/templates/leads/category_list.html
+++ b/leads/templates/leads/category_list.html
@@ -24,14 +24,24 @@
                 <td class="px-4 py-3">Unassigned</td>
                 <td class="px-4 py-3">{{ unassigned_lead_count }}</td>
             </tr>
-            {% for category in category_list %}
+            <!-- {% for category in category_list %}
                 <tr>
                     <td class="px-4 py-3">
                       <a class="hover:text-blue-500" href="{% url 'leads:category-detail' category.pk %}">{{ category.name }}</a>
                     </td>
                     <td class="px-4 py-3">TODO count</td>
                 </tr>
-            {% endfor %}
+            {% endfor %} -->
+                
+            {% for ret in reset %}
+              <div>
+                <tr>
+                  <td class="px-4 py-3" > <a href="{% url 'leads:category-detail' ret.id %}">{{ ret.name }} </a></td>
+                  <td class="px-4 py-3">{{ ret.number }}</td>
+                </tr>
+              </div>
+            {% endfor %} 
+
           </tbody>
         </table>
       </div>


### PR DESCRIPTION
Now all the lead count in category list are updated properly. I'm not sure if it's the best practice, since I didn't save the update number on the database. 
# Adding Number field to the category model.
# Passing the data that we extracted from the "Leads: Views" to the "Category_list" template.
# The "leads/views.py" is able to obtain the number of leads that belong to a specific category and pushing through the "context" to the "category_list" template.